### PR TITLE
Fix PHP 7.4 fatal error caused by str_contains() in feed render path

### DIFF
--- a/app/Views/public/feeds-templates/tiktok/elements/media.php
+++ b/app/Views/public/feeds-templates/tiktok/elements/media.php
@@ -13,10 +13,10 @@ $wpsr_tiktok_description = Arr::get($feed, 'text', ''); // phpcs:ignore WordPres
 $wpsr_tiktok_display_mode = Arr::get($template_meta, 'post_settings.display_mode'); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $wpsr_tiktok_media_url = Arr::get($feed, 'media_url', ''); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $wpsr_tiktok_default_media = Arr::get($feed, 'media.preview_image_url', ''); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-$wpsr_tiktok_img_class = !empty($wpsr_tiktok_media_url) && !str_contains($wpsr_tiktok_media_url, 'placeholder') ? 'wpsr-tt-post-img wpsr-show' : 'wpsr-tt-post-img wpsr-hide'; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+$wpsr_tiktok_img_class = !empty($wpsr_tiktok_media_url) && strpos($wpsr_tiktok_media_url, 'placeholder') === false ? 'wpsr-tt-post-img wpsr-show' : 'wpsr-tt-post-img wpsr-hide'; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $wpsr_tiktok_video_url = 'https://www.tiktok.com/@'.$wpsr_tiktok_user_name.'/video/'.$wpsr_tiktok_feed_id; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $wpsr_tiktok_image_optimization = Arr::get($image_settings, 'optimized_images'); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-$wpsr_tiktok_animation_img_class = str_contains($wpsr_tiktok_media_url, 'placeholder') && $wpsr_tiktok_media_url ? 'wpsr-animated-background' : ''; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+$wpsr_tiktok_animation_img_class = $wpsr_tiktok_media_url && strpos($wpsr_tiktok_media_url, 'placeholder') !== false ? 'wpsr-animated-background' : ''; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $wpsr_tiktok_attrs = [


### PR DESCRIPTION
## Problem
Audit finding HIGH-02: The plugin declares "Requires PHP: 7.4" in readme.txt (line 6), but the media template used str_contains() — a PHP 8.0+ function — on the live shortcode render path:
  renderTiktokTemplate() → template1.php → renderFeedMedia() → elements/media.php
This caused a fatal error on any PHP 7.4 site rendering a TikTok feed. Reference: customfeed-for-tiktok.md audit report, HIGH-02.

## Solution
File: app/Views/public/feeds-templates/tiktok/elements/media.php

- Line 16: Replaced `!str_contains($wpsr_tiktok_media_url, 'placeholder')` with `strpos($wpsr_tiktok_media_url, 'placeholder') === false`. This is the negated check used to assign the 'wpsr-show'/'wpsr-hide' CSS class for the feed image.

- Line 19: Replaced `str_contains($wpsr_tiktok_media_url, 'placeholder') && $wpsr_tiktok_media_url` with `$wpsr_tiktok_media_url && strpos($wpsr_tiktok_media_url, 'placeholder') !== false`. Also reordered the && operands so the truthiness check on the variable comes first (short-circuit avoids calling strpos on an empty string). This controls the 'wpsr-animated-background' CSS class.

strpos() is available since PHP 4, fully compatible with the declared PHP 7.4 minimum.