### PR TITLE
Fix author-name visibility wired to author-photo setting

### DIFF
--- a/app/Services/Platforms/Feeds/Tiktok/Config.php
+++ b/app/Services/Platforms/Feeds/Tiktok/Config.php
@@ -61,7 +61,7 @@ class Config
                     'resolution'              => Arr::get($settings,'post_settings.resolution', 'full'),
                     'display_mode'            => Arr::get($settings,'post_settings.display_mode', 'tiktok'),
                     'display_author_photo'    => Arr::get($settings,'post_settings.display_author_photo', 'true'),
-                    'display_author_name'     => Arr::get($settings,'post_settings.display_author_photo', 'true'),
+                    'display_author_name'     => Arr::get($settings,'post_settings.display_author_name', 'true'),
                     'display_date'            => Arr::get($settings,'post_settings.display_date', 'true'),
                     'display_description'     => Arr::get($settings,'post_settings.display_description', 'true'),
                     'display_views_count'     => Arr::get($settings,'post_settings.display_views_count', 'true'),


### PR DESCRIPTION
## Problem
Audit finding MEDIUM-02: In Config::formatTiktokConfig(), the display_author_name config key was reading its value from post_settings.display_author_photo instead of
post_settings.display_author_name (line 64 of Config.php).

This meant the author-name toggle was slaved to the author-photo toggle — disabling the photo also hid the name, and enabling the name independently was impossible after settings were normalized.

The author-name template (elements/author-name.php:8) renders only when display_author_name === 'true', so the misconfigured key caused a silent frontend rendering bug.

Reference: customfeed-for-tiktok.md audit report, MEDIUM-02.

## Solution
File: app/Services/Platforms/Feeds/Tiktok/Config.php

- Line 64: Changed the Arr::get() source key from 'post_settings.display_author_photo' to 'post_settings.display_author_name' so the display_author_name config reads from its own setting key.

This was a copy-paste typo — the line above (display_author_photo) has the identical structure, and the key was duplicated instead of updated when the author_name line was added.

## Questions & Answers
No questions were asked during this task.