### PR TITLE
Extend TikTok template filter to Pro templates

### DIFF
--- a/app/Hooks/Handlers/TiktokTemplateHandler.php
+++ b/app/Hooks/Handlers/TiktokTemplateHandler.php
@@ -127,7 +127,7 @@ class TiktokTemplateHandler
             'image_settings' => $gdpr_settings
         ];
 
-        if ($templateNumber === 'template2') {
+        if (defined('WPSOCIALREVIEWS_PRO') && $templateNumber !== 'template1') {
             $html = apply_filters('custom_feed_for_tiktok/add_tiktok_feed_template', $template_body_data); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
             return $html;
         } else {


### PR DESCRIPTION
Replace the hard-coded 'template2' check with a condition that applies the custom_feed_for_tiktok/add_tiktok_feed_template filter when WPSOCIALREVIEWS_PRO is defined and the template is not 'template1'. This allows the filter to run for all Pro templates except template1 instead of only for 'template2'.

## What does this PR do and why?

<!-- What: brief description of the change. Why: the problem or need behind it. Link the issue if one exists: Fixes #123 -->



## Changes

<!-- Tick the categories that apply. Delete any that don't apply. -->

- [ ] PHP (feed logic, services, hooks)
- [ ] TikTok API integration (OAuth, token refresh, endpoints, field selectors)
- [ ] Template rendering (shortcode, template tags, header/grid/footer)
- [ ] Page builder widgets (Elementor, Oxygen, Beaver Builder)
- [ ] Core dependency (WP Social Ninja `RemoteAuth`, `BaseFeed`, `PlatformErrorManager`, etc.)
- [ ] Build / config

## How to test

<!--
Steps for the reviewer to verify this works.
Be specific — which feed type, which settings page, what input, what to expect.
-->

1.

## Screenshots

<!-- If there are UI or widget changes, paste before/after screenshots. Remove this section if not applicable. -->

## Anything the reviewer should know?

<!-- Edge cases, trade-offs, things you're unsure about, or areas you'd like extra scrutiny on. Leave blank if nothing comes to mind. -->
