### PR TITLE
Add minimal header layout option with profile photo border styling for TikTok feeds

### DIFF
--- a/app/Services/Platforms/Feeds/Tiktok/Config.php
+++ b/app/Services/Platforms/Feeds/Tiktok/Config.php
@@ -28,6 +28,11 @@ class Config
             $selectedAccounts = Arr::get($settings, 'source_settings.account_ids', [0 => $firstKey]);
         }
 
+        $header_layout = Arr::get($settings, 'header_settings.header_layout', 'classic');
+        if (!in_array($header_layout, array('classic', 'minimal'), true)) {
+            $header_layout = 'classic';
+        }
+
         return array(
             'feed_settings' => array(
                 'platform'                  => 'tiktok',
@@ -73,6 +78,7 @@ class Config
                 ),
                 'header_settings' => array(
                     'display_header'             => Arr::get($settings,'header_settings.display_header', 'true'),
+                    'header_layout'              => $header_layout,
                     'account_to_show'            => Arr::get($settings,'header_settings.account_to_show', $firstKey),
                     'display_profile_photo'      => Arr::get($settings,'header_settings.display_profile_photo', 'true'),
                     'display_page_name'          => Arr::get($settings,'header_settings.display_page_name', 'true'),
@@ -133,6 +139,27 @@ class Config
             'header' => array(
                 'title' => __('Header', 'custom-feed-for-tiktok'),
                 'key'  => 'header',
+                array(
+                    'title'     => __('Profile Photo', 'custom-feed-for-tiktok'),
+                    'key'      => 'profile_photo',
+                    'divider' => true,
+                    'typography' => false,
+                    'padding' => false,
+                    'border' => false,
+                    'condition' => array(
+                        'key' => 'header_settings.header_layout',
+                        'selector'  => 'minimal',
+                    ),
+                    'styles' => array(
+                        array(
+                            'title'      => __('Border Color:', 'custom-feed-for-tiktok'),
+                            'fieldKey'  => 'border_color',
+                            'type'      => 'color_picker',
+                            'flex'      => true,
+                            'disabled' => !$has_pro,
+                        )
+                    )
+                ),
                 array(
                     'title'     => __('User Name', 'custom-feed-for-tiktok'),
                     'key'      => 'user_name',
@@ -504,6 +531,13 @@ class Config
         $prefix = '.wpsr-tiktok-feed-template-'.$postId;
         return [
             'styles' => array(
+                'profile_photo' => array(
+                    // Scoped to the minimal layout — that is the only header that rings the photo.
+                    'selector' => $prefix.' .wpsr-tiktok-feed-header.wpsr-tiktok-feed-header-layout-minimal .wpsr-tiktok-feed-user-info-wrapper .wpsr-tiktok-feed-user-info-head .wpsr-tiktok-feed-header-info .wpsr-tiktok-feed-user-profile-pic img',
+                    'color'  => array(
+                        'border_color' => Arr::get($settings,'styles.profile_photo.color.border_color', '')
+                    )
+                ),
                 'user_name' => array(
                     'selector' => $prefix.' .wpsr-tiktok-feed-header .wpsr-tiktok-feed-user-info-wrapper .wpsr-tiktok-feed-user-info-head .wpsr-tiktok-feed-header-info .wpsr-tiktok-feed-user-info .wpsr-tiktok-feed-user-info-name-wrapper a',
                     'color'  => array(

--- a/app/Services/Platforms/Feeds/Tiktok/Helper.php
+++ b/app/Services/Platforms/Feeds/Tiktok/Helper.php
@@ -16,4 +16,24 @@ class Helper
         $sourceList = Arr::get($configs, 'sources') ? $configs['sources'] : [];
         return $sourceList;
     }
+
+    /**
+     *
+     * Resolve the header layout CSS class from the feed settings.
+     * 'classic' keeps the original header, 'minimal' renders the flat header.
+     *
+     * @param $feed_settings
+     *
+     * @return string
+     *
+     **/
+    public static function getHeaderLayoutClass($feed_settings = [])
+    {
+        $layout = Arr::get($feed_settings, 'header_settings.header_layout', 'classic');
+        if (!in_array($layout, array('classic', 'minimal'), true)) {
+            $layout = 'classic';
+        }
+
+        return 'wpsr-tiktok-feed-header-layout-' . $layout;
+    }
 }

--- a/app/Views/public/feeds-templates/tiktok/header.php
+++ b/app/Views/public/feeds-templates/tiktok/header.php
@@ -1,5 +1,6 @@
 <?php
 
+use CustomFeedForTiktok\Application\Services\Platforms\Feeds\Tiktok\Helper as TiktokHelper;
 use WPSocialReviews\Framework\Support\Arr;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -42,6 +43,8 @@ $wpsr_tiktok_display_profile_photo = Arr::get($wpsr_tiktok_header_settings, 'dis
 $wpsr_tiktok_profile_photo_hide_class = $wpsr_tiktok_display_profile_photo === 'false' ? 'wpsr-tiktok-feed-profile-pic-hide' : ''; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $wpsr_tiktok_display_header = Arr::get($wpsr_tiktok_header_settings, 'display_header'); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 
+$wpsr_tiktok_header_layout_class = TiktokHelper::getHeaderLayoutClass($feed_settings); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+
 echo '<div  id="wpsr-tiktok-feed-' . esc_attr($templateId) . '" class="' . esc_attr(implode(' ', $wpsr_tiktok_classes)) . '" ' . esc_attr(implode(' ',
         $wpsr_tiktok_data_attrs)) . '  data-column="' . esc_attr($wpsr_tiktok_desktop_column_number) . '">';
 echo '<div class="wpsr-loader">
@@ -55,7 +58,7 @@ if ($wpsr_tiktok_display_header === 'true' && !empty($header)) {
     $wpsr_tiktok_profile_deep_link = Arr::get($header, 'profile_deep_link', ''); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 
     echo '<div class="wpsr-row">
-        <div class="wpsr-tiktok-feed-header wpsr-col-12 ' . ($wpsr_tiktok_header_settings['display_profile_photo'] === 'false' ? 'wpsr-tiktok-feed-profile-pic-hide' : '') . '">
+        <div class="wpsr-tiktok-feed-header ' . esc_attr($wpsr_tiktok_header_layout_class) . ' wpsr-col-12 ' .($wpsr_tiktok_header_settings['display_profile_photo'] === 'false' ? 'wpsr-tiktok-feed-profile-pic-hide' : '') . '">
             <div class="wpsr-tiktok-feed-user-info-wrapper">
                 <div class="wpsr-tiktok-feed-user-info-head">
                     <div class="wpsr-tiktok-feed-header-info">';


### PR DESCRIPTION
## What does this PR do and why?

Adds a `header_layout` setting to the TikTok feed header so a feed can render either the existing `classic` header or a new flat `minimal` header. The chosen layout is emitted as a `wpsr-tiktok-feed-header-layout-*` class on the feed header wrapper, which gives the stylesheet and the style engine a stable hook to target per-layout.

Alongside it, a Pro-gated **Profile Photo → Border Color** control is added to the Header styling tab. The minimal header is the only layout that rings the profile photo, so the control is conditioned on `header_layout === 'minimal'` and its generated selector is scoped to that layout class — the classic header is left untouched.

## Changes

- [x] PHP (feed logic, services, hooks)
- [x] Template rendering (shortcode, template tags, header/grid/footer)

### Feed config — `app/Services/Platforms/Feeds/Tiktok/Config.php`

- Read `header_settings.header_layout` from the saved settings, whitelist it against `('classic', 'minimal')`, and fall back to `classic` for any unknown or missing value (`Config.php:31`).
- Expose the resolved value as `header_settings.header_layout` in the returned feed config (`Config.php:81`).
- Add a `profile_photo` group to the Header styling tab with a single **Border Color** `color_picker` field, `disabled` when Pro is inactive, and a `condition` on `header_settings.header_layout` matching `minimal` (`Config.php:142`).
- Add the matching `profile_photo` style entry, scoped to `.wpsr-tiktok-feed-header.wpsr-tiktok-feed-header-layout-minimal … .wpsr-tiktok-feed-user-profile-pic img` (`Config.php:534`).

### Helper — `app/Services/Platforms/Feeds/Tiktok/Helper.php`

- Add `Helper::getHeaderLayoutClass()`, which resolves the layout from the feed settings using the same whitelist/fallback and returns `wpsr-tiktok-feed-header-layout-<layout>`.

### Template — `app/Views/public/feeds-templates/tiktok/header.php`

- Import the TikTok `Helper` as `TiktokHelper`.
- Resolve the layout class once from `$feed_settings` and print it, escaped, on the `.wpsr-tiktok-feed-header` wrapper alongside the existing `wpsr-col-12` and profile-photo-hide classes.

## How to test

1. Activate **Custom Feed for TikTok** with a connected TikTok source and create (or open) a TikTok feed template.
2. On the feed's **Header** settings, leave the layout at its default. Render the feed on a page and confirm the header wrapper carries `wpsr-tiktok-feed-header-layout-classic` and looks exactly as it did before this PR.
3. Switch the header layout to **Minimal**, save, and reload the front end. The wrapper class should change to `wpsr-tiktok-feed-header-layout-minimal`.
4. Open the **Styling → Header** tab. The **Profile Photo** group with the **Border Color** picker should appear only while the layout is `minimal`, and should be greyed out on the free version.
5. With Pro active and the minimal layout selected, pick a border color and save. Confirm the generated CSS targets the profile photo `img` inside the minimal header only, and that switching back to `classic` leaves the photo unstyled.
6. Confirm `display_profile_photo = false` still hides the photo in both layouts (the `wpsr-tiktok-feed-profile-pic-hide` class is unaffected).

## Anything the reviewer should know?

- **The layout picker control is not in this repo.** `Config.php` only returns feed defaults and the styling-tab schema; the actual header settings fields (including the `header_layout` select) are defined in WP Social Ninja core. This PR is the consume-and-render side only — a missing `header_settings.header_layout` key is expected on older core builds and is handled by the `classic` fallback.
- **The minimal-layout CSS is also external.** No stylesheet in this repo defines `.wpsr-tiktok-feed-header-layout-minimal`; the class is a hook for core/Pro styles plus the generated style-engine rules. An "unused selector" flag on that class would be a false positive.
- **The whitelist is duplicated deliberately.** `Config::getFeedConfig()` and `Helper::getHeaderLayoutClass()` each validate the layout independently because the template can be rendered from a cached/serialized feed config that never passes back through `Config`. Neither should trust the other to have sanitized it.
- **PHP 7.4 target** — no null-safe operator, no arrow-function shorthand, no union types. `array()` syntax is used inside `Config.php` to match the surrounding file; `Helper.php` mixes `[]` and `array()` for the same reason.
- `in_array(..., true)` is intentionally strict — a non-string value from a corrupted setting must fall back rather than loosely match.
- The style selector is long and highly specific on purpose: it mirrors the existing `user_name` / header selectors in the same array, which need that specificity to beat the base template styles.
- `esc_attr()` on the layout class is belt-and-braces — the value is already constrained to two literals — but it keeps the template consistent with every other interpolated class there.
- `Helper.php` still has no trailing newline (pre-existing; the diff only appends to it).

## Human reviewer notes

- Testing the minimal layout end-to-end needs a WP Social Ninja core build that ships the `header_layout` field and the minimal header styles. Without it the setting is never written, and the feed correctly falls back to `classic` — that is the expected behaviour, not a bug.
- The Border Color picker requires WP Social Ninja Pro (`WPSOCIALREVIEWS_PRO`) to be enabled; on the free version it should render disabled rather than hidden.